### PR TITLE
Fixing circular Uuids error

### DIFF
--- a/aorist_concept/src/enum_builder.rs
+++ b/aorist_concept/src/enum_builder.rs
@@ -108,10 +108,10 @@ impl Builder for EnumBuilder {
               // ix
               Option<usize>,
               // uuid
-              Uuid,
+              Option<Uuid>,
               // wrapped reference
               &'a #enum_name
-          )> for WrappedConcept<'a, T> where 
+          )> for WrappedConcept<'a, T> where
           #(
               T: [<CanBe #variant>]<'a>,
           )* {
@@ -120,7 +120,7 @@ impl Builder for EnumBuilder {
                       &str,
                       Option<&str>,
                       Option<usize>,
-                      Uuid,
+                      Option<Uuid>,
                       &'a #enum_name,
                   )
               ) -> Self {
@@ -128,7 +128,7 @@ impl Builder for EnumBuilder {
                   match children_enum {
                       #(
                           #enum_name::#variant(x) => WrappedConcept{
-                              inner: T::[<construct_ #variant:snake:lower>](x, ix, Some((uuid, name.to_string()))),
+                              inner: T::[<construct_ #variant:snake:lower>](x, ix, Some((uuid.unwrap(), name.to_string()))),
                               _phantom_lt: std::marker::PhantomData,
                           },
                       )*
@@ -144,10 +144,10 @@ impl Builder for EnumBuilder {
           impl <'a> ConceptEnum<'a> for &'a #enum_name {}
           pub trait [<CanBe #enum_name>]<'a> {
               fn [<construct_ #enum_name:snake:lower>] (
-                  obj_ref: &'a #enum_name, 
-                  ix: Option<usize>, 
+                  obj_ref: &'a #enum_name,
+                  ix: Option<usize>,
                   id: Option<(Uuid, String)>
-              ) -> Self; 
+              ) -> Self;
           }
           impl <'a> AoristConcept<'a> for #enum_name {
             type TChildrenEnum = &'a #enum_name;
@@ -159,14 +159,14 @@ impl Builder for EnumBuilder {
                 // ix
                 Option<usize>,
                 // uuid
-                Uuid,
+                Option<Uuid>,
                 &'a #enum_name
             )> {
                 vec![(
                     stringify!(#enum_name),
                     None,
                     None,
-                    self.get_uuid(),
+                    Some(self.get_uuid()),
                     &self
                 )]
             }

--- a/aorist_concept/src/struct_builder.rs
+++ b/aorist_concept/src/struct_builder.rs
@@ -237,10 +237,10 @@ impl Builder for StructBuilder {
                 // ix
                 Option<usize>,
                 // uuid
-                Uuid,
+                Option<Uuid>,
                 // wrapped reference
                 [<#struct_name Children>]<'a>
-            )> for WrappedConcept<'a, T> where 
+            )> for WrappedConcept<'a, T> where
             #(
                 T: [<CanBe #types>]<'a>,
             )* {
@@ -249,7 +249,7 @@ impl Builder for StructBuilder {
                         &str,
                         Option<&str>,
                         Option<usize>,
-                        Uuid,
+                        Option<Uuid>,
                         [<#struct_name Children>]<'a>
                     )
                 ) -> Self {
@@ -257,7 +257,7 @@ impl Builder for StructBuilder {
                     match children_enum {
                         #(
                             [<#struct_name Children>]::#types(x) => WrappedConcept{
-                                inner: T::[<construct_ #types:snake:lower>](x, ix, Some((uuid, name.to_string()))),
+                                inner: T::[<construct_ #types:snake:lower>](x, ix, Some((uuid.unwrap(), name.to_string()))),
                                 _phantom_lt: std::marker::PhantomData,
                             },
                         )*
@@ -291,7 +291,7 @@ impl Builder for StructBuilder {
             &self.option_vec_types,
             &self.map_value_types,
         );
-        
+
         let types = self.get_all_types();
         TokenStream::from(quote! { paste! {
 
@@ -314,15 +314,15 @@ impl Builder for StructBuilder {
             impl <'a> ConceptEnum<'a> for [<#struct_name Children>]<'a> {}
             pub trait [<CanBe #struct_name>]<'a> {
                 fn [<construct_ #struct_name:snake:lower>](
-                    obj_ref: &'a #struct_name, 
-                    ix: Option<usize>, 
+                    obj_ref: &'a #struct_name,
+                    ix: Option<usize>,
                     id: Option<(Uuid, String)>
-                ) -> Self; 
+                ) -> Self;
             }
 
 
             impl <'a> AoristConcept<'a> for #struct_name {
-                
+
                 type TChildrenEnum = [<#struct_name Children>]<'a>;
 
                 fn get_tag(&self) -> Option<String> {
@@ -336,7 +336,7 @@ impl Builder for StructBuilder {
                     // ix
                     Option<usize>,
                     // uuid
-                    Uuid,
+                    Option<Uuid>,
                     // wrapped reference
                     [<#struct_name Children>]<'a>,
                 )> {
@@ -346,7 +346,7 @@ impl Builder for StructBuilder {
                             stringify!(#struct_name),
                             Some(stringify!(#bare_ident)),
                             None,
-                            self.get_uuid(),
+                            self.uuid,
                             [<#struct_name Children>]::#bare_type(&self.#bare_ident)
                         ));
                     )*
@@ -356,7 +356,7 @@ impl Builder for StructBuilder {
                                 stringify!(#struct_name),
                                 Some(stringify!(#option_ident)),
                                 None,
-                                self.get_uuid(),
+                                self.uuid,
                                 [<#struct_name Children>]::#option_type(c)
                             ));
                         }
@@ -367,7 +367,7 @@ impl Builder for StructBuilder {
                                 stringify!(#struct_name),
                                 Some(stringify!(#vec_ident)),
                                 Some(ix),
-                                self.get_uuid(),
+                                self.uuid,
                                 [<#struct_name Children>]::#vec_type(elem)
                             ));
                         }
@@ -379,7 +379,7 @@ impl Builder for StructBuilder {
                                     stringify!(#struct_name),
                                     Some(stringify!(#option_vec_ident)),
                                     Some(ix),
-                                    self.get_uuid(),
+                                    self.uuid,
                                     [<#struct_name Children>]::#option_vec_type(elem)
                                 ));
                             }
@@ -391,7 +391,7 @@ impl Builder for StructBuilder {
                                 stringify!(#struct_name),
                                 Some(stringify!(#map_ident)),
                                 None,
-                                self.get_uuid(),
+                                self.uuid,
                                 [<#struct_name Children>]::#map_value_type(elem)
                             ));
                         }
@@ -402,7 +402,7 @@ impl Builder for StructBuilder {
                     if let Some(uuid) = self.uuid {
                         return uuid.clone();
                     }
-                    panic!("Uuid was not set on object.");
+                    panic!("Uuid was not set on object of type {}.", stringify!(#struct_name));
                 }
                 fn get_children_uuid(&self) -> Vec<Uuid> {
                     self.get_children().iter().map(|x| x.4.get_uuid()).collect()

--- a/aorist_core/src/concept/mod.rs
+++ b/aorist_core/src/concept/mod.rs
@@ -8,7 +8,7 @@ pub trait Ancestry<'a> {
     type TConcept: ConceptEnum<'a>;
 }
 pub trait AoristConcept<'a> {
-    
+
     type TChildrenEnum: ConceptEnum<'a>;
 
     fn get_children(&'a self) -> Vec<(
@@ -19,7 +19,7 @@ pub trait AoristConcept<'a> {
         // ix
         Option<usize>,
         // uuid
-        Uuid,
+        Option<Uuid>,
         // wrapped reference
         Self::TChildrenEnum,
     )>;
@@ -30,6 +30,7 @@ pub trait AoristConcept<'a> {
     fn get_uuid_from_children_uuid(&self) -> Uuid {
         let child_uuids = self.get_children_uuid();
         if child_uuids.len() > 0 {
+            eprintln!("There are child uuids.");
             let uuids = child_uuids.into_iter().collect::<BTreeSet<Uuid>>();
             let mut hasher = SipHasher::new();
             for uuid in uuids {
@@ -38,6 +39,7 @@ pub trait AoristConcept<'a> {
             let bytes: [u8; 16] = hasher.finish128().as_bytes();
             Uuid::from_bytes(bytes)
         } else {
+            eprintln!("There are no child uuids.");
             // TODO: this should just be created from the hash
             Uuid::new_v4()
         }


### PR DESCRIPTION
Fixes #8. A recent refactor I started created the following behavior:
- to compute an aorist object's Uuid, we get the children's Uuids, if the object has any children.
- to compute children's Uuid, we get a children vector wrapping each child, regardless of type -- my refactor unified this behavior.
- in the process of computing this children vector, I also "cleverly" added the object's own Uuid.

BUT: the object's Uuid wasn't computed, in the first place! This resulted in a panic.

*Test plan*: 
1. managed to reproduce the error following @aidanscienz's description.
2. running the code no longer produces the error.